### PR TITLE
Bugfix - pass predict_difference variable to Dynamics

### DIFF
--- a/mbrl/model_based_agent/active_exploration_model_based_agents.py
+++ b/mbrl/model_based_agent/active_exploration_model_based_agents.py
@@ -45,7 +45,8 @@ class PetsActiveExplorationModelBasedAgent(BaseModelBasedAgent):
         dynamics, system, actor = ExplorationDynamics, ExplorationSystem, PetsActor
         dynamics = dynamics(statistical_model=self.statistical_model,
                             x_dim=self.env.observation_size,
-                            u_dim=self.env.action_size)
+                            u_dim=self.env.action_size,
+                            predict_difference=self.predict_difference)
         system = system(dynamics=dynamics,
                         reward=self.reward_model, )
         actor = actor(env_observation_size=self.env.observation_size,
@@ -82,7 +83,8 @@ class PetsActiveExplorationModelBasedAgent(BaseModelBasedAgent):
             model = copy.deepcopy(self.statistical_model)
             dynamics = dynamics_type(statistical_model=model,
                                      x_dim=self.env.observation_size,
-                                     u_dim=self.env.action_size)
+                                     u_dim=self.env.action_size,
+                                     predict_difference=self.predict_difference)
             system = system_type(dynamics=dynamics,
                                  reward=reward_model, )
             actor = actor_type(env_observation_size=self.env.observation_size,
@@ -205,7 +207,8 @@ class OptimisticActiveExplorationModelBasedAgent(PetsActiveExplorationModelBased
         dynamics, system, actor = OptimisticExplorationDynamics, OptimisticExplorationSystem, OptimisticActor
         dynamics = dynamics(statistical_model=self.statistical_model,
                             x_dim=self.env.observation_size,
-                            u_dim=self.env.action_size)
+                            u_dim=self.env.action_size,
+                            predict_difference=self.predict_difference)
         system = system(dynamics=dynamics,
                         reward=self.reward_model, )
         actor = actor(env_observation_size=self.env.observation_size,

--- a/mbrl/model_based_agent/optimistic_model_based_agent.py
+++ b/mbrl/model_based_agent/optimistic_model_based_agent.py
@@ -14,7 +14,8 @@ class OptimisticModelBasedAgent(BaseModelBasedAgent):
         dynamics, system, actor = OptimisticDynamics, OptimisticSystem, OptimisticActor
         dynamics = dynamics(statistical_model=self.statistical_model,
                             x_dim=self.env.observation_size,
-                            u_dim=self.env.action_size)
+                            u_dim=self.env.action_size,
+                            predict_difference = self.predict_difference)
         system = system(dynamics=dynamics,
                         reward=self.reward_model, )
         actor = actor(env_observation_size=self.env.observation_size,

--- a/mbrl/model_based_agent/pets_model_based_agent.py
+++ b/mbrl/model_based_agent/pets_model_based_agent.py
@@ -14,7 +14,8 @@ class PETSModelBasedAgent(BaseModelBasedAgent):
         dynamics, system, actor = PetsDynamics, PetsSystem, PetsActor
         dynamics = dynamics(statistical_model=self.statistical_model,
                             x_dim=self.env.observation_size,
-                            u_dim=self.env.action_size)
+                            u_dim=self.env.action_size,
+                            predict_difference=self.predict_difference)
         system = system(dynamics=dynamics,
                         reward=self.reward_model, )
         actor = actor(env_observation_size=self.env.observation_size,

--- a/mbrl/model_based_agent/when_to_control_model_based.py
+++ b/mbrl/model_based_agent/when_to_control_model_based.py
@@ -47,7 +47,8 @@ class WhenToControlModelBasedAgent(BaseModelBasedAgent):
                             min_time_between_switches=self.min_time_between_switches,
                             max_time_between_switches=self.max_time_between_switches,
                             episode_time=self.episode_time,
-                            dt=self.dt)
+                            dt=self.dt,
+                            predict_difference=self.predict_difference)
         system = system(dynamics=dynamics,
                         reward=self.reward_model, )
         actor = actor(env_observation_size=self.env.observation_size,


### PR DESCRIPTION
predict_difference is a boolean that indicates whether the statistical model directly predicts the next_state or the difference between next_state and state. It is initialized [here](https://github.com/lasgroup/model-based-rl/blob/167293cf821f8ec9b620d5bbec90aff832972445/mbrl/model_based_agent/base_model_based_agent.py#L67) in BaseModelBasedAgent. The data buffer is created from the true environment [here](https://github.com/lasgroup/model-based-rl/blob/167293cf821f8ec9b620d5bbec90aff832972445/mbrl/model_based_agent/base_model_based_agent.py#L164).

Later, the Actor is initialized with prepare_actor, for example [here](https://github.com/lasgroup/model-based-rl/blob/167293cf821f8ec9b620d5bbec90aff832972445/mbrl/model_based_agent/pets_model_based_agent.py#L11). There, the [Dynamics](https://github.com/lasgroup/model-based-rl/blob/167293cf821f8ec9b620d5bbec90aff832972445/mbrl/model_based_agent/system_wrapper/system_wrapper.py#L29C1-L29C50) that need to be learned are initialized. The Dynamics also have a predict_difference attribute [here](https://github.com/lasgroup/model-based-rl/blob/167293cf821f8ec9b620d5bbec90aff832972445/mbrl/model_based_agent/system_wrapper/system_wrapper.py#L34), but this is never passed during initialization in the Actor [here](https://github.com/lasgroup/model-based-rl/blob/167293cf821f8ec9b620d5bbec90aff832972445/mbrl/model_based_agent/pets_model_based_agent.py#L15).
This means the Actor->Dynamics always learns with the default value predict_difference=true, even if predict_difference=false is set in BaseModelBasedAgent.

This fix passes the predict_difference bool from the Model Based Agent to the Actor.